### PR TITLE
Add VS code build/generate tasks (for #18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.vscode
 bin
 obj
 obs-studio

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "dotnet.defaultSolution": "NetObsBindings.sln"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,46 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build (Debug)",
+      "command": "dotnet",
+      "type": "process",
+      "options": {
+        "cwd": "${workspaceFolder}/NetObsBindings"
+      },
+      "args": [
+        "build",
+        "-c",
+        "Debug"
+      ],
+      "problemMatcher": "$msCompile",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "build (Release)",
+      "command": "dotnet",
+      "type": "process",
+      "options": {
+        "cwd": "${workspaceFolder}/NetObsBindings"
+      },
+      "args": [
+        "build",
+        "-c",
+        "Release"
+      ],
+      "problemMatcher": "$msCompile",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Generate C# bindings",
+      "type": "shell",
+      "command": ".\\build.ps1"
+    }
+  ]
+}


### PR DESCRIPTION
With this VS Code users can easily open the NetObsBindings main folder and from there both run the PS generation scripts as VS tasks and build the library with Debug and Release config.

For people not using VS Code the folder shouldn't cause any issues, it's simply ignored. For more details and a screenshot see #18.